### PR TITLE
Fix https problem viewing charts using https in some browsers

### DIFF
--- a/src/main/java/org/databene/contiperf/report/GoogleLatencyRenderer.java
+++ b/src/main/java/org/databene/contiperf/report/GoogleLatencyRenderer.java
@@ -58,7 +58,7 @@ public class GoogleLatencyRenderer {
 	dataset.scaleY(80);
 	try {
 	    StringBuilder builder = new StringBuilder(
-		    "http://chart.apis.google.com/chart?cht=lxy"); // xy line
+		    "https://chart.apis.google.com/chart?cht=lxy"); // xy line
 								   // chart
 	    builder.append("&chs=").append(width).append('x').append(height); // image
 									      // size


### PR DESCRIPTION
Some browsers will not include unsecure content when viewing the report page.

Change the url http://chart.apis.google.com to https://chart.apis.google.com , resolves the problem 

Example : https://www.hack23.com/jenkins/view/UnionVms/job/UVMS-Docker-dev/74/Performance_Report/ 
Do not work in chrome.

Best regards

